### PR TITLE
update region.sql

### DIFF
--- a/region.sql
+++ b/region.sql
@@ -45,7 +45,7 @@ INSERT INTO `region` (`id`, `region`) VALUES
 (9, 'Souss - Massa'),
 (10, 'Guelmim - Oued Noun'),
 (11, 'Laâyoune - Sakia El Hamra'),
-(12, 'Dakhla-Oued Eddahab'),
+(12, 'Dakhla-Oued Eddahab');
 
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;

--- a/region.sql
+++ b/region.sql
@@ -34,22 +34,19 @@ CREATE TABLE IF NOT EXISTS `region` (
 --
 
 INSERT INTO `region` (`id`, `region`) VALUES
-(1, 'Grand Casablanca'),
-(2, 'Chaouia-Ouardigha'),
-(3, 'Doukkala-Abda'),
-(4, 'Fès-Boulemane'),
-(5, 'Gharb-Chrarda-Beni Hssen'),
-(6, 'Guelmim-Es Semara'),
-(7, 'Marrakech-Tensift-Al Haouz'),
-(8, 'Meknès-Tafilalet'),
-(9, 'l''''Oriental'),
-(10, 'Rabat-Salé-Zemmour-Zaër'),
-(11, 'Souss-Massa-Draâ'),
-(12, 'Tadla-Azilal'),
-(13, 'Tanger-Tétouan'),
-(14, 'Taza-Al Hoceïma-Taounate'),
-(15, 'Laayoune-Boujdour-Sakia-Hamra'),
-(16, 'Oued-Eddahab-Lagouira');
+(1, 'Tanger – Tétouan – Al Hoceima'),
+(2, 'l''''Oriental'),
+(3, 'Fès - Meknès'),
+(4, 'Rabat - Salé- Kénitra'),
+(5, 'Béni Mellal- Khénifra'),
+(6, 'Casablanca- Settat'),
+(7, 'Marrakech - Safi'),
+(8, 'Darâa - Tafilalet'),
+(9, 'Souss - Massa'),
+(10, 'Guelmim - Oued Noun'),
+(11, 'Laâyoune - Sakia El Hamra'),
+(12, 'Dakhla-Oued Eddahab'),
+
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
 /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;


### PR DESCRIPTION
Le Maroc s’est doté d’un nouveau découpage territorial. Il compte désormais 12 Régions selon le Décret n°2.15.10 du 20 Février 2015, fixant le nombre des Régions, leurs noms, leurs Chefs lieux et les Préfectures et Provinces les composant, publié au Bulletin Officiel n° 6340 du 05  Mars 2015. 
le Décret n°2.15.10 du 20 Février 2015, fixant le nombre des Régions, leurs noms, leurs Chefs lieux et les Préfectures et Provinces les composant : [http://www.pncl.gov.ma/fr/EspaceJuridique/DocLib/d%C3%A9cret%20fixant%20le%20nombre%20des%20r%C3%A9gions.pdf](http://www.pncl.gov.ma/fr/EspaceJuridique/DocLib/d%C3%A9cret%20fixant%20le%20nombre%20des%20r%C3%A9gions.pdf)
